### PR TITLE
chore: add browser unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Retool helper functions that run in a browser environment (don't use Node APIs).
 ## To Do
 
 - Add publishing to npm to release creation workflow.
-- Use an actual browser compatible test framework for the browser tests.
 
 ## Development
 
@@ -19,8 +18,8 @@ The Typescript is compiled into ESM and CJS compatible modules. The ESM modules 
 
 ## Testing
 
-- Unit tests: `npm run test`
-- Browser tests: `npm run browser-test`, you will need to open the console to check that the function has been imported and run.
+- Unit tests: `npm run test` - these run in CI, but will not throw if you accidentally include Node APIs in the library.
+- Browser tests: `npm run browser-test`, this will open a local browser window and run Mocha tests in it. These don't run in CI because we can't extract the test result. Because they run in a browser they will throw if you accidentally include non-Browser APIs, e.g. Node's `process.env`.
 
 ## Publishing
 

--- a/browser_test/index.html
+++ b/browser_test/index.html
@@ -1,17 +1,31 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Testing</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
-    <script type="module">
-      import { add } from "../lib/esm/index.js";
-      console.log("add 1 and 2 using an imported module", add(1, 2));
-    </script>
+    <title>Mocha Tests</title>
+    <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
   </head>
   <body>
-    <div class="message">open the console</div>
+    <div id="mocha"></div>
+
+    <script type="module" src="https://unpkg.com/chai/chai.js"></script>
+    <script type="module" src="https://unpkg.com/mocha/mocha.js"></script>
+
+    <script type="module" class="mocha-init">
+      mocha.setup("bdd");
+      mocha.checkLeaks();
+    </script>
+    <script type="module">
+      import oak from "../lib/esm/index.js";
+      describe("add things up", () => {
+        it("adds 1 and 1", () => {
+          chai.assert(oak.add(1, 1), 2);
+        });
+      });
+    </script>
+    <script type="module" class="mocha-exec">
+      mocha.run();
+    </script>
   </body>
 </html>

--- a/browser_test/main.css
+++ b/browser_test/main.css
@@ -1,7 +1,0 @@
-.message {
-  width: 100%;
-  height: 100vh;
-  line-height: 100vh;
-  text-align: center;
-  font-size: xx-large;
-}

--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "allowJs": false,
     "declaration": true,
     "declarationMap": true,
     "allowSyntheticDefaultImports": true

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "prebrowser-test": "npm run build",
-    "browser-test": "http-server -o browser_test",
+    "browser-test": "http-server -c-1 -o browser_test",
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "build:cjs": "tsc -p ./configs/tsconfig.cjs.json",
     "build:esm": "tsc -p ./configs/tsconfig.esm.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@
  * @param b
  * @returns
  */
-export const add = (a: number, b: number): number => a + b;
+export const add = (a: number, b: number): number => {
+  return a + b;
+};
 
 export default {
   add,


### PR DESCRIPTION
Add unit tests that can run in a browser environment, mostly to prove that the tested functions don't accidentally include Node APIs.

It's frustrating that we can't run those tests in CI. I did look at [Karma](https://github.com/karma-runner/karma), but it just doesn't work with ESModules in the browser as far as I can see. Annoyingly, that also means we have two separate test suites. I'd suggest the in-browser Mocha one is used as a sanity test only.

Separate to this PR, the question remains, can Retool use code provided in modules like this, or do we need an additional output directory that bundles the code?