### PR TITLE
test(npm): testing different object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ export { slugify };
 // will be exposed on the Window object as
 // `OakRetoolHelpers`.
 const oakRetoolHelpers = {
-  slugify,
+  slugify: slugify,
+  testing: "This is a test"
 };
 declare global {
   interface Window {


### PR DESCRIPTION
## Description

- Changed the returned object to use slugify: slugify

## Issue(s)
 Retool doesn't recognise the slugify function as a function.
Fixes #
 Testing if a slightly different formulation will work

## How to test

## Checklist

- [x] Added or updated tests where appropriate
