### PR TITLE
chore(revert): target older syntaxes

### DIFF
--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -8,7 +8,7 @@
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
     "lib": ["ES2022", "DOM"],
-    "target": "ES5"
+    "target": "ES2022"
   },
   "files": ["../src/index.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postbuild": "npm run bundle",
     "build:cjs": "tsc -p ./configs/tsconfig.cjs.json",
     "build:esm": "tsc -p ./configs/tsconfig.esm.json",
-    "bundle": "esbuild lib/cjs/index.js --bundle --target=chrome70 --outfile=lib/bundle/index.js",
+    "bundle": "esbuild lib/esm/index.js --bundle --target=chrome98 --outfile=lib/bundle/index.js",
     "check-types": "tsc --project configs/tsconfig.esm.json",
     "clean": "rm -rf ./lib",
     "lint": "eslint .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { slugify };
 // will be exposed on the Window object as
 // `OakRetoolHelpers`.
 const oakRetoolHelpers = {
-  slugify: slugify,
+  slugify,
 };
 declare global {
   interface Window {


### PR DESCRIPTION
Reverts oaknational/Retool-Helpers#10 because Retool helped us figure out how to use this library as it was.