### PR TITLE
fix: update special characters to escape correctly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@oaknational/content-squad

--- a/src/handleSpecialCharacters/index.test.ts
+++ b/src/handleSpecialCharacters/index.test.ts
@@ -22,7 +22,7 @@ describe("handleSpecialCharacters", () => {
             String.fromCharCode(9) +
             "tab"
         )
-      ).toBe(`\ttab\ttab\ttab`);
+      ).toBe(`\\\\ttab\\\\ttab\\\\ttab`);
     });
     test("removeSpecialCharacters - line feed all characters", () => {
       expect(
@@ -34,7 +34,7 @@ describe("handleSpecialCharacters", () => {
             String.fromCharCode(10) +
             "feed"
         )
-      ).toBe(`\ncheck\nthe\nfeed`);
+      ).toBe(`\\\\ncheck\\\\nthe\\\\nfeed`);
     });
     test("removeSpecialCharacters - carriage return all characters", () => {
       expect(
@@ -46,7 +46,7 @@ describe("handleSpecialCharacters", () => {
             String.fromCharCode(13) +
             "now"
         )
-      ).toBe(`\rreturn\rcheck\rnow`);
+      ).toBe(`\\\\rreturn\\\\rcheck\\\\rnow`);
     });
     test("removeSpecialCharacters - backslash all characters", () => {
       expect(
@@ -73,7 +73,7 @@ describe("handleSpecialCharacters", () => {
       );
     });
     test("insertSpecialCharacters - tab all characters", () => {
-      expect(insertSpecialCharacters(`\ttab\ttab\ttab`)).toBe(
+      expect(insertSpecialCharacters(`\\ttab\\ttab\\ttab`)).toBe(
         String.fromCharCode(9) +
           "tab" +
           String.fromCharCode(9) +
@@ -83,7 +83,7 @@ describe("handleSpecialCharacters", () => {
       );
     });
     test("insertSpecialCharacters - line feed all characters", () => {
-      expect(insertSpecialCharacters(`\ncheck\nthe\nfeed`)).toBe(
+      expect(insertSpecialCharacters(`\\ncheck\\nthe\\nfeed`)).toBe(
         String.fromCharCode(10) +
           "check" +
           String.fromCharCode(10) +
@@ -93,7 +93,7 @@ describe("handleSpecialCharacters", () => {
       );
     });
     test("insertSpecialCharacters - carriage return all characters", () => {
-      expect(insertSpecialCharacters(`\rreturn\rcheck\rnow`)).toBe(
+      expect(insertSpecialCharacters(`\\rreturn\\rcheck\\rnow`)).toBe(
         String.fromCharCode(13) +
           "return" +
           String.fromCharCode(13) +

--- a/src/handleSpecialCharacters/index.ts
+++ b/src/handleSpecialCharacters/index.ts
@@ -8,9 +8,9 @@ export const removeSpecialCharacters = (text: string): string => {
   return text
     .replace("'", "’")
     .replace('"', "”")
-    .replaceAll(String.fromCharCode(10), "\n")
-    .replaceAll(String.fromCharCode(13), "\r")
-    .replaceAll(String.fromCharCode(9), "\t")
+    .replaceAll(String.fromCharCode(10), "\\n")
+    .replaceAll(String.fromCharCode(13), "\\r")
+    .replaceAll(String.fromCharCode(9), "\\t")
     .replaceAll(String.fromCharCode(92), String.fromCharCode(92, 92));
 };
 
@@ -24,8 +24,8 @@ export const insertSpecialCharacters = (text: string): string => {
   return text
     .replace("’", "'")
     .replace("”", '"')
-    .replaceAll("\n", String.fromCharCode(10))
-    .replaceAll("\r", String.fromCharCode(13))
-    .replaceAll("\t", String.fromCharCode(9))
+    .replaceAll("\\n", String.fromCharCode(10))
+    .replaceAll("\\r", String.fromCharCode(13))
+    .replaceAll("\\t", String.fromCharCode(9))
     .replaceAll(String.fromCharCode(92, 92), String.fromCharCode(92));
 };


### PR DESCRIPTION
## Description

- Remove special characters needed updating to escape the escape characters (i.e. `\\n` instead of `\n`)
- add codeowners

## Checklist

- [x] Added or updated tests where appropriate
