### PR TITLE
fix: include the lesson id in parsed updates

### DIFF
--- a/src/bulkUploads/parseUpdates.test.ts
+++ b/src/bulkUploads/parseUpdates.test.ts
@@ -130,6 +130,21 @@ describe("parseUpdates", () => {
     expect(parsedThree.keywords).toStrictEqual(threeK2);
   });
 
+  test("should include the lesson ID in the parsed updates", () => {
+    const { parsedUpdates } = parseUpdates(
+      bulkUpdates,
+      currentRecordsMap,
+      updateFields,
+      conversionMaps
+    );
+
+    parsedUpdates.forEach((update) => {
+      const current = currentRecordsMap.get(update.lesson_uid!);
+
+      expect(update.lesson_id).toEqual(current?.lesson_id);
+    });
+  });
+
   describe("Errors", () => {
     test("should log the error if a field is longer than its max length", () => {
       const customBulkUpdates = [...bulkUpdates];

--- a/src/bulkUploads/parseUpdates.ts
+++ b/src/bulkUploads/parseUpdates.ts
@@ -251,6 +251,7 @@ export const parseUpdates = (
         lesson_uid: update.lesson_uid,
         title: currentRecord.title,
         pupil_lesson_outcome: currentRecord.pupil_lesson_outcome,
+        lesson_id: currentRecord.lesson_id,
       };
 
       let key: keyof UpdateFields;


### PR DESCRIPTION
## Description

- The parsed updates were missing lesson IDs causing bulk updates to fail, this PR includes the lesson ID 

## Checklist

- [x] Added or updated tests where appropriate
