### PR TITLE
[ENG-1337] Use OIDC to connect to NPM

### DIFF
--- a/.github/workflows/create_semantic_release.yml
+++ b/.github/workflows/create_semantic_release.yml
@@ -17,6 +17,8 @@ jobs:
   semantic_release:
     name: semantic release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -44,4 +46,3 @@ jobs:
           # workflows, if you need that see
           # https://github.com/semantic-release/github#github-authentication
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


## Description

- This approach eliminates the security risks associated with long-lived write tokens, which can be compromised, accidentally exposed in logs, or require manual rotation. Instead, each publish uses short-lived, cryptographically-signed tokens that are specific to the workflow and cannot be extracted or reused.

- This removes the existing long-lived `NPM_TOKEN` and adds `id-token: write` permission, which allows GitHub Actions to generate OIDC tokens

## Issue(s)
[ENG-1337](https://www.notion.so/oaknationalacademy/Use-OIDC-to-connect-to-NPM-27926cc4e1b180ba8268ce99adfde268)

## How to test

## Checklist

- [ ] Added or updated tests where appropriate
