### PR TITLE
[ENG-1337] Adds NPM_TOKEN

### DIFF
--- a/.github/workflows/create_semantic_release.yml
+++ b/.github/workflows/create_semantic_release.yml
@@ -17,8 +17,6 @@ jobs:
   semantic_release:
     name: semantic release
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -46,3 +44,4 @@ jobs:
           # workflows, if you need that see
           # https://github.com/semantic-release/github#github-authentication
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

## Description

- semantic-release/npm still insists on an NPM_TOKEN variable during its verifyConditions step even when OIDC is enabled.

## Issue(s)

## Issue(s)
[ENG-1337](https://www.notion.so/oaknationalacademy/Use-OIDC-to-connect-to-NPM-27926cc4e1b180ba8268ce99adfde268)

## How to test

## Checklist

- [ ] Added or updated tests where appropriate
